### PR TITLE
画像のリサイズとオーバーフローの設定

### DIFF
--- a/app/assets/stylesheets/_chat.scss
+++ b/app/assets/stylesheets/_chat.scss
@@ -22,6 +22,13 @@
   &__message{
     box-sizing: border-box;
     padding: 46px 40px 0;
+    height: calc(100vh - 190px);
+    overflow: scroll;
+
+    img{
+      width: 200px;
+      height: 200px;
+    }
   }
 
   &__form{


### PR DESCRIPTION
what
CSSファイルにて画像のリサイズとオーバーフローの設定を行った。

why
要素がでかくなると飛び出てしまっていたため